### PR TITLE
Sort transactions by index in block as well as height

### DIFF
--- a/bitcoin/phored/wallet.go
+++ b/bitcoin/phored/wallet.go
@@ -1129,6 +1129,7 @@ type ReceivedTx struct {
 	tx          wire.MsgTx
 	blockHeight int32
 	blockTime   time.Time
+	blockIndex  int32
 }
 
 // RetrieveTransactions fetches transactions from the rpc server and stores them into the database
@@ -1161,7 +1162,8 @@ func (w *RPCWallet) RetrieveTransactions() error {
 
 	transactions = append(transactions, w.receiveTransactions(scriptAddresses, false)...)
 	sort.SliceStable(transactions, func(i, j int) bool {
-		return transactions[i].blockHeight < transactions[j].blockHeight
+		return transactions[i].blockHeight < transactions[j].blockHeight ||
+			(transactions[i].blockHeight == transactions[j].blockHeight && transactions[i].blockIndex < transactions[j].blockIndex)
 	})
 
 	for _, tx := range transactions {
@@ -1240,7 +1242,26 @@ func (w *RPCWallet) receiveTransactions(addrs []btc.Address, lookAhead bool) []R
 				continue
 			}
 
-			transactions = append(transactions, ReceivedTx{transaction, int32(block.Height), time.Unix(block.Time, 0)})
+			// replace this by sending the index of the transaction in the block
+			index := int32(-1)
+
+			for i, transactionHex := range block.Tx {
+				if transactionHex == transaction.TxHash().String() {
+					index = int32(i)
+				}
+			}
+
+			if index == -1 {
+				log.Errorf("could not find transaction in block")
+				continue
+			}
+
+			transactions = append(transactions, ReceivedTx{
+				tx:          transaction,
+				blockHeight: int32(block.Height),
+				blockTime:   time.Unix(block.Time, 0),
+				blockIndex:  index,
+			})
 		}
 	}
 	return transactions

--- a/core/core.go
+++ b/core/core.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	VERSION   = "2.0.1"
+	VERSION   = "2.0.2"
 	USERAGENT = "/Phore-Marketplace-go:" + VERSION + "/"
 )
 


### PR DESCRIPTION
This fixes bugs where balances were shown incorrectly because the input would be processed after the transaction spending the input if the transactions were in the same block and sorted incorrectly.